### PR TITLE
Kafka v0.10.1.1 image not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos
 RUN mkdir -p /opt/kafka \
   && cd /opt/kafka \
   && yum -y install java-1.8.0-openjdk-headless tar \
-  && curl -s https://www.mirrorservice.org/sites/ftp.apache.org/kafka/0.10.1.1/kafka_2.11-0.10.1.1.tgz | tar -xz --strip-components=1 \
+  && curl -s https://www.mirrorservice.org/sites/ftp.apache.org/kafka/0.10.2.1/kafka_2.11-0.10.2.1.tgz | tar -xz --strip-components=1 \
   && yum clean all
 RUN chmod -R a=u /opt/kafka
 WORKDIR /opt/kafka


### PR DESCRIPTION
Kafka v0.10.1.1 image not found at location `https://www.mirrorservice.org/sites/ftp.apache.org/kafka/0.10.1.1/kafka_2.11-0.10.1.1.tgz`.

Replaced with v0.10.2.1 located at `https://www.mirrorservice.org/sites/ftp.apache.org/kafka/0.10.2.1/kafka_2.11-0.10.2.1.tgz`